### PR TITLE
Use fork of copy-text-to-clipboard to avoid fat arrow functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "state-copy",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "copy-text-to-clipboard": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,8 @@
   "requires": true,
   "dependencies": {
     "copy-text-to-clipboard": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-1.0.2.tgz",
-      "integrity": "sha1-SAkoNmXyS0KGrL/Upn2LIJ6uFoA="
+      "version": "github:deliriousrhino/copy-text-to-clipboard#d1305ccfbbaad58d4ad4a3a4a80bbb366eaba582",
+      "from": "github:deliriousrhino/copy-text-to-clipboard#master"
     },
     "fast-safe-stringify": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": " <jake @o91tsjBgL0l0zs475aRWYSAXFxvirZS7VrXmirY/msI=.ed25519>",
   "license": "MIT",
   "dependencies": {
-    "copy-text-to-clipboard": "^1.0.2",
+    "copy-text-to-clipboard": "github:deliriousrhino/copy-text-to-clipboard#master",
     "fast-safe-stringify": "^1.2.0"
   },
   "repository": {


### PR DESCRIPTION
Fixes #1 . I'm not sure how you like to verify or tests etc so if you could check it out and make sure everything's fine that would be great.

* Use forked repo directly - currently set to master branch but can change to a specific commit if preferred.
* Add gitignore to ignore node_modules - helped to inspect changes without worrying about committing dependencies. Again, can remove if preferred.